### PR TITLE
Use correct feature of typenum crate dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ std = [
 ]
 
 [dependencies]
-typenum = { version = "1.14.0", features = ["derive_scale_info"], git = "https://github.com/encointer/typenum" }
+typenum = { version = "1.14.0", features = ["derive_scale"], git = "https://github.com/encointer/typenum" }
 az = { version = "0.3", optional = true }
 half = { version = "1.4", optional = true }
 serde = { version = "1.0.60", default-features = false, optional = true }


### PR DESCRIPTION
The feature name seems to have changed in the dependency.
I would also recommend referring to a specific tag or release branch so the change to typenum cannot spuriously break the build of dependents of substrate-fixed.