### PR TITLE
bump scale-codec v3, scale-info v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,12 @@ std = [
 ]
 
 [dependencies]
-typenum = { tag = "v1.15.0", features = ["derive_scale"], git = "https://github.com/encointer/typenum" }
+typenum = { tag = "v1.16.0", features = ["derive_scale"], git = "https://github.com/encointer/typenum" }
 az = { version = "0.3", optional = true }
 half = { version = "1.4", optional = true }
 serde = { version = "1.0.60", default-features = false, optional = true }
-scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "2.3.1", default-features = false, features = ["derive", "max-encoded-len"] }
+scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
 
 [dev-dependencies]
 rand = { version = "0.7", default-features = false }


### PR DESCRIPTION
Tested that newest substrate-compiles after this change.