### PR TITLE
Derive `DecodeWithMemTracking` for the fixed types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,4 +57,4 @@ name = "bench_main"
 harness = false
 
 #[patch.crates-io]
-#typenum = { package = "substrate-typenum", path = "../typenum"}
+#substrate-typenum = { path = "../typenum"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "substrate-fixed"
-version = "0.5.9"
+version = "0.6.0"
 authors = [
   "Trevor Spiteri <tspiteri@ieee.org>",
   "Encointer Association <info@encointer.org>",
@@ -34,10 +34,10 @@ typenum = { package = "substrate-typenum", version = "1.17.0", features = [
 az = { version = "0.3", optional = true }
 half = { version = "1.4", optional = true }
 serde = { version = "1.0.60", default-features = false, optional = true }
-scale-info = { version = "2.5.0", default-features = false, features = [
+scale-info = { version = "2.11.6", default-features = false, features = [
   "derive",
 ] }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", version = "3.7.4", default-features = false, features = [
   "derive",
   "max-encoded-len",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ fail-on-warnings = []
 std = ["codec/std", "serde/std", "scale-info/std"]
 
 [dependencies]
-typenum = { package = "substrate-typenum", version = "1.16.0", features = [
+typenum = { package = "substrate-typenum", version = "1.17.0", features = [
   "derive_scale",
 ] }
 az = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,5 +56,5 @@ features = ["az", "f16", "serde", "std"]
 name = "bench_main"
 harness = false
 
-#[patch."https://github.com/encointer/typenum"]
-#typenum = { path = "../typenum"}
+#[patch.crates-io]
+#typenum = { package = "substrate-typenum", path = "../typenum"}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,7 @@ mod macros_no_frac;
 #[macro_use]
 mod macros_frac;
 
-use codec::{Decode, Encode, MaxEncodedLen};
+use codec::{Decode, Encode, DecodeWithMemTracking, MaxEncodedLen};
 macro_rules! fixed {
     (
         $description:expr,
@@ -361,7 +361,7 @@ assert_eq!(two_point_75.to_string(), \"2.8\");
 [typenum crate]: https://crates.io/crates/typenum
 ";
             #[repr(transparent)]
-            #[derive(Encode, Decode, scale_info::TypeInfo, MaxEncodedLen)]
+            #[derive(Encode, Decode, DecodeWithMemTracking, scale_info::TypeInfo, MaxEncodedLen)]
             pub struct $Fixed<Frac> {
                 bits: $Inner,
                 phantom: PhantomData<Frac>,


### PR DESCRIPTION
New parity-scale-codec trait that needs to be implemented.

Todos:
- [x] wait until typenum v1.17.0 is released, see https://github.com/encointer/typenum/pull/4
- [x] release this crate as v0.6.0